### PR TITLE
Telephony: Use regular poll state when radio off for RIL versions < 10

### DIFF
--- a/src/java/com/android/internal/telephony/ServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/ServiceStateTracker.java
@@ -947,7 +947,11 @@ public class ServiceStateTracker extends Handler {
                 }
                 // This will do nothing in the 'radio not available' case
                 setPowerStateToDesired();
-                modemTriggeredPollState();
+                if (mCi.getRilVersion() >= 10) {
+                    modemTriggeredPollState();
+                } else {
+                    pollState();
+                }
                 break;
 
             case EVENT_NETWORK_STATE_CHANGED:


### PR DESCRIPTION
The modemTriggeredPollState breaks airplane mode on some devices.
Although the UI shows that airplane mode is activated, the fact is that
the radio remains active and in service. By using original AOSP pollState()
here, service state in sim status shows correctly radio off.

Change-Id: If2ab5b088a13b1a159e01f82fbea1f58a77b64cd