### PR TITLE
DCT: Tear down MMS+default connections raised by config_enable_mms_wi…

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
@@ -2580,6 +2580,13 @@ public class DcTracker extends Handler {
                 }
             } else if (met) {
                 apnContext.setReason(Phone.REASON_DATA_DISABLED);
+                CarrierConfigManager configManager = (CarrierConfigManager)mPhone.getContext().
+                        getSystemService(Context.CARRIER_CONFIG_SERVICE);
+                PersistableBundle pb = configManager.getConfigForSubId(mPhone.getSubId());
+                boolean mmsWithMobileDataOff = false;
+                if (pb != null) {
+                    mmsWithMobileDataOff = pb.getBoolean("config_enable_mms_with_mobile_data_off");
+                }
                 // If ConnectivityService has disabled this network, stop trying to bring
                 // it up, but do not tear it down - ConnectivityService will do that
                 // directly by talking with the DataConnection.
@@ -2590,7 +2597,9 @@ public class DcTracker extends Handler {
                 // can declare the DUN APN sharable by default traffic, thus still satisfying
                 // those requests and not torn down organically.
                 if ((apnContext.getApnType() == PhoneConstants.APN_TYPE_DUN && teardownForDun())
-                        || apnContext.getState() != DctConstants.State.CONNECTED) {
+                        || apnContext.getState() != DctConstants.State.CONNECTED
+                        || (mmsWithMobileDataOff &&
+                                   apnContext.getApnType().equals(PhoneConstants.APN_TYPE_MMS))) {
                     cleanup = true;
                 } else {
                     cleanup = false;


### PR DESCRIPTION
…th_mobile_data_off

If the tracker lets an MMS connection go through even if data is off, make sure
it's torn down once the disabled state gets applied. More often than not, APNs
configured as MMS+data would remain alive, and the tracker's state machine would
get stuck out of sync

Ref: CYNGNOS-3239

Change-Id: Ia13e9ff5beea44ecfda40a4910990dab53af25dd